### PR TITLE
use maven-shared-utils instead of deprecated plexus-utils 

### DIFF
--- a/plantuml-maven-plugin/pom.xml
+++ b/plantuml-maven-plugin/pom.xml
@@ -16,6 +16,13 @@
             <artifactId>plantuml</artifactId>
             <version>1.2023.1</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-shared-utils</artifactId>
+            <version>3.3.4</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>

--- a/plantuml-maven-plugin/src/main/java/com/github/davidmoten/plantuml/plugins/GenerateMojo.java
+++ b/plantuml-maven-plugin/src/main/java/com/github/davidmoten/plantuml/plugins/GenerateMojo.java
@@ -16,7 +16,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.FileUtils;
+import org.apache.maven.shared.utils.io.FileUtils;
 
 import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.FileFormatOption;


### PR DESCRIPTION
plexus-utils is no longer available by default in Maven 3.9.0+ so using the plugin with Maven 3.9.0+ gives this error:

```
Error:  Failed to execute goal com.github.davidmoten:plantuml-maven-plugin:0.2.1:generate (generate-diagrams) on project
rxjava3-pool: Execution generate-diagrams of goal com.github.davidmoten:plantuml-maven-plugin:0.2.1:generate failed: A
required class was missing while executing com.github.davidmoten:plantuml-maven-plugin:0.2.1:generate: org/codehaus/plexus/util/FileUtils
```
This PR adds maven-shared-utils dependency as an explicit dependency and uses its FileUtils replacement class.