### PR TITLE
add threadSafe = true to GenerateMojo

### DIFF
--- a/plantuml-maven-plugin/src/main/java/com/github/davidmoten/plantuml/plugins/GenerateMojo.java
+++ b/plantuml-maven-plugin/src/main/java/com/github/davidmoten/plantuml/plugins/GenerateMojo.java
@@ -24,7 +24,7 @@ import net.sourceforge.plantuml.GeneratedImage;
 import net.sourceforge.plantuml.SourceFileReader;
 import net.sourceforge.plantuml.preproc.Defines;
 
-@Mojo(name = "generate")
+@Mojo(name = "generate", threadSafe = true)
 public final class GenerateMojo extends AbstractMojo {
 
     @Parameter(name = "sources")


### PR DESCRIPTION
As requested in #4.

The plugin writes to the file system and that writing relies on the internals of plantuml library and the configuration of the plugin by the user so their are opportunities for some conflict but you'd have to try pretty hard to provoke them. For that reason I'm happy to add the annotation property of threadSafe = true to reduce build stdout noise.